### PR TITLE
Include new/uncommitted files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     unicode-display_width (2.3.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ rubocop --require rubocop-changed
 
 ## Additionally
 
-The default branch for comparing gets by: 
+The default branch for comparing gets by:
 ```bash
 git symbolic-ref refs/remotes/origin/HEAD # usually it's main or master
 ```
 For custom branch set env:  `RUBOCOP_CHANGED_BRANCH_NAME`
+
+## Thanks
+- [Steve Hall](https://github.com/sh41)
 
 ## Similar Gems
 

--- a/lib/rubocop/changed/version.rb
+++ b/lib/rubocop/changed/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Changed
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
   end
 end

--- a/spec/rubocop/changed/commands_spec.rb
+++ b/spec/rubocop/changed/commands_spec.rb
@@ -11,6 +11,7 @@ describe RuboCop::Changed::Commands do
       current_branch: current_branch
     )
     allow(described_class).to(receive(:shell).with(changed_files_command).and_return(files.join("\n")))
+    allow(described_class).to(receive(:shell).with(git[:new_files]).and_return(''))
     allow(described_class).to(receive(:shell).with(git[:current_branch]).and_return(current_branch))
     allow(described_class).to(receive(:shell).with(git[:default_branch]).and_return(default_branch))
   end
@@ -58,6 +59,25 @@ describe RuboCop::Changed::Commands do
       expect(described_class).to receive(:shell).with(format(git[:changed_files], compared_branch: default_branch,
                                                                                   current_branch: current_branch))
       expect(described_class.changed_files('main')).to eq(files.map { |file| File.absolute_path(file) })
+    end
+  end
+
+  context 'when returns new_files' do
+    let(:files) { %w[file1.rb file2.rb new_file1.rb new_file2.rb] }
+
+    before do
+      status_porcelain_output = <<~STDOUT
+         M file1.rb
+        ?? new_file1.rb
+        ?? new_file2.rb
+      STDOUT
+
+      allow(described_class).to(receive(:shell).with(git[:new_files]).and_return(status_porcelain_output))
+    end
+
+    it 'returns changed & new files' do
+      expect(described_class.changed_files('main')).to eq(files.map { |file| File.absolute_path(file) })
+      expect(described_class).to have_received(:shell).with('git status --porcelain=v1')
     end
   end
 end


### PR DESCRIPTION
Hi, thanks for a really useful plugin. I wanted to use it in development as well, but it was filtering out files that I hadn't yet committed. This change includes those files by appending the output of `git status --porcelain` to the original file list. 

I hope you'll find this is a useful addition to an already really useful extension. 