### PR TITLE
Fix name of Exception

### DIFF
--- a/lib/rubocop/changed/command_error.rb
+++ b/lib/rubocop/changed/command_error.rb
@@ -6,23 +6,30 @@ module RuboCop
     class CommandError < StandardError
       ISSUE_URL = 'https://github.com/dukaev/rubocop-changed/issues'
       MESSAGES = {
-        'git: not found' => 'Git is not installed. Make shure that container has git installed',
-        'fatal: not a git repository' => 'Not found .git directory. Make shure that branch is copied',
-        'fatal: ambiguous argument' => 'Not found setted branch. Make shure that branch is downladed.'
+        'git: not found' =>
+          'The git binary is not available in the PATH. You may need to install git or update the PATH variable to ' \
+          'include the installation directory.',
+        'fatal: not a git repository' =>
+          'The .git directory was not found. Rubocop-changed only works with projects in a git repository.',
+        'fatal: ambiguous argument' =>
+          'The set branch was not found. Ensure that the branch has a local tracking branch or specify the full ' \
+          'reference in the RUBOCOP_CHANGED_BRANCH_NAME environment variable.'
       }.freeze
 
       def initialize(output, cmd)
         key = MESSAGES.keys.find { |error| output.include?(error) }
-        msg = MESSAGES[key] || default_message(cmd, output)
-
-        super(msg)
+        message = MESSAGES[key] || "Unknown error. Please, create issue on #{ISSUE_URL}."
+        super(exception_message(cmd, output, message))
       end
 
-      def default_message(cmd, output)
+      def exception_message(cmd, output, message)
         <<~HEREDOC
-          Unknown error. Please, create issue on #{ISSUE_URL}.
-          Command: #{cmd}
-          Message: #{output}
+          #{message}
+          Command:
+          #{cmd}
+          Output:
+          #{output}
+
         HEREDOC
       end
     end

--- a/lib/rubocop/changed/commands.rb
+++ b/lib/rubocop/changed/commands.rb
@@ -61,7 +61,9 @@ module RuboCop
         end
 
         def run(cmd)
+          warn("COMMAND: #{cmd}") if verbose_logging?
           output = shell(cmd)
+          warn("OUTPUT:  #{output}\n") if verbose_logging?
           raise CommandError.new(output, cmd) if output.match?(Regexp.union(ERRORS))
 
           output
@@ -69,6 +71,10 @@ module RuboCop
 
         def shell(cmd)
           `#{cmd} 2>&1`
+        end
+
+        def verbose_logging?
+          ENV.fetch('RUBOCOP_CHANGED_VERBOSE_LOGGING', false) != false
         end
       end
     end

--- a/lib/rubocop/changed/commands.rb
+++ b/lib/rubocop/changed/commands.rb
@@ -62,7 +62,7 @@ module RuboCop
 
         def run(cmd)
           output = shell(cmd)
-          raise Rubocop::Changed::ExecutionError.new(output, cmd) if output.match?(Regexp.union(ERRORS))
+          raise CommandError.new(output, cmd) if output.match?(Regexp.union(ERRORS))
 
           output
         end

--- a/lib/rubocop/changed/version.rb
+++ b/lib/rubocop/changed/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Changed
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/rubocop-changed.gemspec
+++ b/rubocop-changed.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['lib/**/*.rb']
 
-  spec.add_development_dependency('rspec', '~> 3.12.0')
   spec.add_runtime_dependency('rubocop', '>= 1.0.0')
 end

--- a/spec/rubocop/changed/command_error_spec.rb
+++ b/spec/rubocop/changed/command_error_spec.rb
@@ -8,43 +8,65 @@ describe RuboCop::Changed::CommandError do
   context 'when git command is not found' do
     let(:cmd) { 'git rev-parse --abbrev-ref HEAD' }
     let(:output) { 'git: not found' }
+    let(:exception_help_string) do
+      'The git binary is not available in the PATH. ' \
+        'You may need to install git or update the PATH variable to include the installation directory.'
+    end
 
     it 'returns error message' do
-      expect(subject).to eq('Git is not installed. Make shure that container has git installed')
+      expect(subject).to eq(expected_error_as_string(exception_help_string, cmd, output))
     end
   end
 
   context 'when .git directory is not found' do
     let(:cmd) { 'git status' }
     let(:output) { 'fatal: not a git repository (or any of the parent directories): .git' }
+    let(:exception_help_string) do
+      'The .git directory was not found. Rubocop-changed only works with projects in a git repository.'
+    end
 
     it 'returns error message' do
-      expect(subject).to eq('Not found .git directory. Make shure that branch is copied')
+      expect(subject).to eq(expected_error_as_string(exception_help_string, cmd, output))
     end
   end
 
-  context 'when settetd branch is not found' do
+  context 'when set branch is not found' do
     let(:cmd) { 'git diff-tree -r --no-commit-id --name-only not_found_branch' }
     let(:output) { "fatal: ambiguous argument 'not_found_branch': unknown revision or path not in the working tree." }
+    let(:exception_help_string) do
+      'The set branch was not found. Ensure that the branch has a local tracking branch or specify the full ' \
+        'reference in the RUBOCOP_CHANGED_BRANCH_NAME environment variable.'
+    end
 
     it 'returns error message' do
-      expect(subject).to eq('Not found setted branch. Make shure that branch is downladed.')
+      expect(subject).to eq(expected_error_as_string(exception_help_string, cmd, output))
     end
   end
 
   context 'when unknown error' do
     let(:cmd) { 'git status' }
     let(:output) { 'fatal: unknown error' }
-    let(:message) do
-      <<~HEREDOC
-        Unknown error. Please, create issue on #{RuboCop::Changed::CommandError::ISSUE_URL}.
-        Command: #{cmd}
-        Message: #{output}
-      HEREDOC
+    let(:exception_help_string) do
+      "Unknown error. Please, create issue on #{RuboCop::Changed::CommandError::ISSUE_URL}."
     end
 
     it 'returns error message' do
-      expect(subject).to eq(message)
+      expect(subject).to eq(expected_error_as_string(exception_help_string, cmd, output))
     end
+
+    it 'contains a link to github' do
+      expect(subject).to match('https://github.com/dukaev/rubocop-changed/')
+    end
+  end
+
+  def expected_error_as_string(message, command, output)
+    <<~HEREDOC
+      #{message}
+      Command:
+      #{command}
+      Output:
+      #{output}
+
+    HEREDOC
   end
 end

--- a/spec/rubocop/changed/commands_spec.rb
+++ b/spec/rubocop/changed/commands_spec.rb
@@ -10,6 +10,7 @@ describe RuboCop::Changed::Commands do
       compared_branch: default_branch,
       current_branch: current_branch
     )
+    allow(ENV).to receive(:fetch).with('RUBOCOP_CHANGED_VERBOSE_LOGGING', false).and_return(false)
     allow(described_class).to(receive(:shell).with(changed_files_command).and_return(files.join("\n")))
     allow(described_class).to(receive(:shell).with(git[:new_files]).and_return(''))
     allow(described_class).to(receive(:shell).with(git[:current_branch]).and_return(current_branch))


### PR DESCRIPTION
Hi @dukaev,

I was also running into issues similar to #2 and found that the Error class that should have provided more information was named incorrectly. 

This fixes that issue and allows the error to be displayed. This was the original output: 
```
uninitialized constant #<Class:RuboCop::Changed::Commands>::Rubocop
/app_gems/ruby/3.2.0/gems/rubocop-changed-0.0.3/lib/rubocop/changed/commands.rb:65:in `run'
/app_gems/ruby/3.2.0/gems/rubocop-changed-0.0.3/lib/rubocop/changed/commands.rb:59:in `default_branch'
/app_gems/ruby/3.2.0/gems/rubocop-changed-0.0.3/lib/rubocop/changed/commands.rb:36:in `compared_branch'
<...snip...>
```

Now I get this: 
```
Unknown error. Please, create issue on https://github.com/dukaev/rubocop-changed/issues.
Command: git symbolic-ref refs/remotes/origin/HEAD
Message: fatal: ref refs/remotes/origin/HEAD is not a symbolic ref

/app_gems/ruby/3.2.0/bundler/gems/rubocop-changed-d3462a0e8af9/lib/rubocop/changed/commands.rb:65:in `run'
/app_gems/ruby/3.2.0/bundler/gems/rubocop-changed-d3462a0e8af9/lib/rubocop/changed/commands.rb:59:in `default_branch'
/app_gems/ruby/3.2.0/bundler/gems/rubocop-changed-d3462a0e8af9/lib/rubocop/changed/commands.rb:36:in `compared_branch'
<...snip...>
```

which tells me where to look to resolve my issue. 